### PR TITLE
[#6] 카드 테이블 구현 (DB)

### DIFF
--- a/app/src/androidTest/java/kr/ksw/mybudget/data/local/CardDaoTest.kt
+++ b/app/src/androidTest/java/kr/ksw/mybudget/data/local/CardDaoTest.kt
@@ -4,10 +4,16 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
 import kr.ksw.mybudget.data.local.dao.CardDao
 import kr.ksw.mybudget.data.local.databases.MyBudgetDatabase
+import kr.ksw.mybudget.data.local.entity.CARD_TYPE_CREDIT
+import kr.ksw.mybudget.data.local.entity.CARD_TYPE_DEBIT
+import kr.ksw.mybudget.data.local.entity.CardEntity
 import org.junit.After
 import org.junit.Before
+import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.IOException
 
@@ -32,5 +38,58 @@ class CardDaoTest {
         db.close()
     }
 
-    
+    @Test
+    fun `Get All Card Entities is Empty`() = runTest {
+        assert(dao.getAllCardEntities().first().isEmpty())
+    }
+
+    @Test
+    fun `Upsert Card Entity`() = runTest {
+        val cardEntity = CardEntity(
+            cardName = "삼성카드 v2",
+            cardNumber = "123456789",
+            cardType = CARD_TYPE_CREDIT
+        )
+        dao.upsertSpendingEntity(cardEntity)
+        val result = dao.getAllCardEntities().first()
+        assert(result.isNotEmpty())
+    }
+
+    @Test
+    fun `Delete Card Entity by Entity`() = runTest {
+        val cardEntity = CardEntity(
+            id = 1,
+            cardName = "삼성카드 v2",
+            cardNumber = "123456789",
+            cardType = CARD_TYPE_CREDIT
+        )
+        dao.upsertSpendingEntity(cardEntity)
+        assert(dao.getAllCardEntities().first().isNotEmpty())
+
+        dao.deleteSpendingEntity(cardEntity)
+        assert(dao.getAllCardEntities().first().isEmpty())
+    }
+
+    @Test
+    fun `Get All Card Entities is Not Empty And Size Two`() = runTest {
+        val cardEntities = listOf(
+            CardEntity(
+                id = 1,
+                cardName = "삼성카드 v2",
+                cardNumber = "123456789",
+                cardType = CARD_TYPE_CREDIT
+            ),
+            CardEntity(
+                id = 2,
+                cardName = "삼성 K패스",
+                cardNumber = "44455578",
+                cardType = CARD_TYPE_DEBIT
+            )
+        )
+        cardEntities.forEach { entity ->
+            dao.upsertSpendingEntity(entity)
+        }
+        assert(dao.getAllCardEntities().first().isNotEmpty())
+        assert(dao.getAllCardEntities().first().size == 2)
+    }
 }

--- a/app/src/androidTest/java/kr/ksw/mybudget/data/local/CardDaoTest.kt
+++ b/app/src/androidTest/java/kr/ksw/mybudget/data/local/CardDaoTest.kt
@@ -1,0 +1,36 @@
+package kr.ksw.mybudget.data.local
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kr.ksw.mybudget.data.local.dao.CardDao
+import kr.ksw.mybudget.data.local.databases.MyBudgetDatabase
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class CardDaoTest {
+    private lateinit var db: MyBudgetDatabase
+    private lateinit var dao: CardDao
+
+    @Before
+    fun createDB() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(
+            context,
+            MyBudgetDatabase::class.java
+        ).build()
+        dao = db.cardDao
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDB() {
+        db.close()
+    }
+
+    
+}

--- a/app/src/androidTest/java/kr/ksw/mybudget/data/local/SpendingDaoTest.kt
+++ b/app/src/androidTest/java/kr/ksw/mybudget/data/local/SpendingDaoTest.kt
@@ -113,7 +113,7 @@ class SpendingDaoTest {
         }
         val from = LocalDate.now()
         val to = LocalDate.now()
-        val result = dao.getSpendingEntitiesBetween(from, to)
+        val result = dao.getSpendingEntitiesBetween(from, to).first()
         assert(result.isNotEmpty())
         assert(result.size == spendingList.size)
     }
@@ -126,7 +126,7 @@ class SpendingDaoTest {
         spendingListForBetween.forEach { spending ->
             dao.upsertSpendingEntity(spending)
         }
-        val result = dao.getSpendingEntitiesBetween(from, to)
+        val result = dao.getSpendingEntitiesBetween(from, to).first()
         assert(result.isNotEmpty())
         assert(result.size == 1)
     }
@@ -139,7 +139,7 @@ class SpendingDaoTest {
         spendingListForBetween.forEach { spending ->
             dao.upsertSpendingEntity(spending)
         }
-        val result = dao.getSpendingEntitiesBetween(from, to)
+        val result = dao.getSpendingEntitiesBetween(from, to).first()
         assert(result.isNotEmpty())
         assert(result.size == 2)
     }
@@ -153,7 +153,7 @@ class SpendingDaoTest {
         spendingListForBetween.forEach { spending ->
             dao.upsertSpendingEntity(spending)
         }
-        val result = dao.getSpendingEntitiesBetween(from, to)
+        val result = dao.getSpendingEntitiesBetween(from, to).first()
         assert(result.isNotEmpty())
         assert(result.size == 1)
     }
@@ -166,7 +166,7 @@ class SpendingDaoTest {
         spendingListForBetween.forEach { spending ->
             dao.upsertSpendingEntity(spending)
         }
-        val result = dao.getSpendingEntitiesBetween(from, now)
+        val result = dao.getSpendingEntitiesBetween(from, now).first()
         assert(result.isNotEmpty())
         assert(result.size == spendingListForBetween.size)
     }
@@ -179,7 +179,7 @@ class SpendingDaoTest {
         spendingListForBetween.forEach { spending ->
             dao.upsertSpendingEntity(spending)
         }
-        val result = dao.getSpendingEntitiesBetweenFlow(from, to).first()
+        val result = dao.getSpendingEntitiesBetween(from, to).first()
         assert(result.isNotEmpty())
         assert(result.size == 1)
     }

--- a/app/src/main/java/kr/ksw/mybudget/data/di/CardModule.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/di/CardModule.kt
@@ -4,10 +4,17 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kr.ksw.mybudget.data.local.dao.CardDao
+import kr.ksw.mybudget.data.repository.card.CardRepository
+import kr.ksw.mybudget.data.repository.card.CardRepositoryImpl
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object CardModule {
-
+    @Provides
+    @Singleton
+    fun provideCardRepository(cardDao: CardDao): CardRepository {
+        return CardRepositoryImpl(cardDao)
+    }
 }

--- a/app/src/main/java/kr/ksw/mybudget/data/di/CardModule.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/di/CardModule.kt
@@ -1,0 +1,13 @@
+package kr.ksw.mybudget.data.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CardModule {
+
+}

--- a/app/src/main/java/kr/ksw/mybudget/data/di/DataModule.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/di/DataModule.kt
@@ -27,4 +27,7 @@ object DataModule {
     @Singleton
     fun provideSpendingDao(myBudgetDatabase: MyBudgetDatabase) = myBudgetDatabase.spendingDao
 
+    @Provides
+    @Singleton
+    fun provideCardDao(myBudgetDatabase: MyBudgetDatabase) = myBudgetDatabase.cardDao
 }

--- a/app/src/main/java/kr/ksw/mybudget/data/local/dao/CardDao.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/local/dao/CardDao.kt
@@ -1,0 +1,20 @@
+package kr.ksw.mybudget.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.mybudget.data.local.entity.CardEntity
+
+@Dao
+interface CardDao {
+    @Upsert
+    suspend fun upsertSpendingEntity(cardEntity: CardEntity)
+
+    @Delete
+    suspend fun deleteSpendingEntity(cardEntity: CardEntity)
+
+    @Query("SELECT * FROM card_table")
+    fun getAllCardEntities(): Flow<List<CardEntity>>
+}

--- a/app/src/main/java/kr/ksw/mybudget/data/local/dao/SpendingDao.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/local/dao/SpendingDao.kt
@@ -30,10 +30,10 @@ interface SpendingDao {
     ): List<SpendingEntity>
 
     @Query("SELECT * FROM spending_table WHERE date BETWEEN :from AND :to")
-    suspend fun getSpendingEntitiesBetween(
+    fun getSpendingEntitiesBetween(
         from: LocalDate,
         to: LocalDate
-    ): List<SpendingEntity>
+    ): Flow<List<SpendingEntity>>
 
     @Query("SELECT * FROM spending_table WHERE date BETWEEN :from AND :to")
     fun getSpendingEntitiesBetweenFlow(

--- a/app/src/main/java/kr/ksw/mybudget/data/local/dao/SpendingDao.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/local/dao/SpendingDao.kt
@@ -34,10 +34,4 @@ interface SpendingDao {
         from: LocalDate,
         to: LocalDate
     ): Flow<List<SpendingEntity>>
-
-    @Query("SELECT * FROM spending_table WHERE date BETWEEN :from AND :to")
-    fun getSpendingEntitiesBetweenFlow(
-        from: LocalDate,
-        to: LocalDate
-    ): Flow<List<SpendingEntity>>
 }

--- a/app/src/main/java/kr/ksw/mybudget/data/local/databases/MyBudgetDatabase.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/local/databases/MyBudgetDatabase.kt
@@ -4,14 +4,17 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import kr.ksw.mybudget.data.local.converter.Converters
+import kr.ksw.mybudget.data.local.dao.CardDao
 import kr.ksw.mybudget.data.local.dao.SpendingDao
+import kr.ksw.mybudget.data.local.entity.CardEntity
 import kr.ksw.mybudget.data.local.entity.SpendingEntity
 
 @Database(
-    entities = [SpendingEntity::class],
+    entities = [SpendingEntity::class, CardEntity::class],
     version = 1
 )
 @TypeConverters(Converters::class)
 abstract class MyBudgetDatabase: RoomDatabase() {
     abstract val spendingDao: SpendingDao
+    abstract val cardDao: CardDao
 }

--- a/app/src/main/java/kr/ksw/mybudget/data/local/entity/CardEntity.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/local/entity/CardEntity.kt
@@ -1,0 +1,16 @@
+package kr.ksw.mybudget.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity("card_table")
+data class CardEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Int? = null,
+    val cardName: String,
+    val cardNumber: String,
+    val cardType: Int,
+)
+
+const val CARD_TYPE_CREDIT = 1
+const val CARD_TYPE_DEBIT = 2

--- a/app/src/main/java/kr/ksw/mybudget/data/repository/card/CardRepository.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/repository/card/CardRepository.kt
@@ -1,0 +1,12 @@
+package kr.ksw.mybudget.data.repository.card
+
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.mybudget.data.local.entity.CardEntity
+
+interface CardRepository {
+    suspend fun upsertSpendingEntity(cardEntity: CardEntity)
+
+    suspend fun deleteSpendingEntity(cardEntity: CardEntity)
+
+    fun getAllCardEntities(): Flow<List<CardEntity>>
+}

--- a/app/src/main/java/kr/ksw/mybudget/data/repository/card/CardRepositoryImpl.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/repository/card/CardRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package kr.ksw.mybudget.data.repository.card
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kr.ksw.mybudget.data.local.dao.CardDao
+import kr.ksw.mybudget.data.local.entity.CardEntity
+import javax.inject.Inject
+
+class CardRepositoryImpl @Inject constructor(
+    private val cardDao: CardDao
+): CardRepository {
+    override suspend fun upsertSpendingEntity(cardEntity: CardEntity) {
+        cardDao.upsertSpendingEntity(cardEntity)
+    }
+
+    override suspend fun deleteSpendingEntity(cardEntity: CardEntity) {
+        cardDao.deleteSpendingEntity(cardEntity)
+    }
+
+    override fun getAllCardEntities(): Flow<List<CardEntity>> = flow {
+        cardDao.getAllCardEntities().collect {
+            emit(it)
+        }
+    }.catch { emit(emptyList()) }
+        .flowOn(Dispatchers.IO)
+}

--- a/app/src/main/java/kr/ksw/mybudget/data/repository/spending/SpendingRepository.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/repository/spending/SpendingRepository.kt
@@ -11,7 +11,7 @@ interface SpendingRepository {
 
     fun getAllSpendingEntities(): Flow<List<SpendingEntity>>
 
-    fun getSpendingEntitiesBetweenFlow(
+    fun getSpendingEntitiesBetween(
         from: LocalDate,
         to: LocalDate
     ): Flow<List<SpendingEntity>>
@@ -22,10 +22,5 @@ interface SpendingRepository {
 
     suspend fun getSpendingEntitiesBySubCategory(
         subCategory: Int
-    ): List<SpendingEntity>
-
-    suspend fun getSpendingEntitiesBetween(
-        from: LocalDate,
-        to: LocalDate
     ): List<SpendingEntity>
 }

--- a/app/src/main/java/kr/ksw/mybudget/data/repository/spending/SpendingRepositoryImpl.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/repository/spending/SpendingRepositoryImpl.kt
@@ -28,11 +28,11 @@ class SpendingRepositoryImpl @Inject constructor(
     }.catch { emit(emptyList()) }
         .flowOn(Dispatchers.IO)
 
-    override fun getSpendingEntitiesBetweenFlow(
+    override fun getSpendingEntitiesBetween(
         from: LocalDate,
         to: LocalDate
     ): Flow<List<SpendingEntity>> = flow {
-        spendingDao.getSpendingEntitiesBetweenFlow(from, to).collect {
+        spendingDao.getSpendingEntitiesBetween(from, to).collect {
             emit(it)
         }
     }.catch { emit(emptyList()) }
@@ -43,9 +43,4 @@ class SpendingRepositoryImpl @Inject constructor(
 
     override suspend fun getSpendingEntitiesBySubCategory(subCategory: Int): List<SpendingEntity>
         = spendingDao.getSpendingEntitiesBySubCategory(subCategory = subCategory)
-
-    override suspend fun getSpendingEntitiesBetween(
-        from: LocalDate,
-        to: LocalDate
-    ): List<SpendingEntity> = spendingDao.getSpendingEntitiesBetween(from, to)
 }

--- a/app/src/main/java/kr/ksw/mybudget/domain/usecase/home/GetMonthlySpendingUseCaseImpl.kt
+++ b/app/src/main/java/kr/ksw/mybudget/domain/usecase/home/GetMonthlySpendingUseCaseImpl.kt
@@ -15,7 +15,7 @@ class GetMonthlySpendingUseCaseImpl @Inject constructor(
         val now = LocalDate.now()
         val from = now.withDayOfMonth(1)
         val to = now.withDayOfMonth(now.lengthOfMonth())
-        return spendingRepository.getSpendingEntitiesBetweenFlow(from, to).map { list ->
+        return spendingRepository.getSpendingEntitiesBetween(from, to).map { list ->
             list.map {
                 it.toItem()
             }

--- a/app/src/main/java/kr/ksw/mybudget/domain/usecase/home/GetPreviousMonthSpendingUseCase.kt
+++ b/app/src/main/java/kr/ksw/mybudget/domain/usecase/home/GetPreviousMonthSpendingUseCase.kt
@@ -1,7 +1,8 @@
 package kr.ksw.mybudget.domain.usecase.home
 
+import kotlinx.coroutines.flow.Flow
 import kr.ksw.mybudget.domain.model.SpendingItem
 
 interface GetPreviousMonthSpendingUseCase {
-    suspend operator fun invoke(): Result<List<SpendingItem>>
+    suspend operator fun invoke(): Flow<List<SpendingItem>>
 }

--- a/app/src/main/java/kr/ksw/mybudget/domain/usecase/home/GetPreviousMonthSpendingUseCaseImpl.kt
+++ b/app/src/main/java/kr/ksw/mybudget/domain/usecase/home/GetPreviousMonthSpendingUseCaseImpl.kt
@@ -1,5 +1,7 @@
 package kr.ksw.mybudget.domain.usecase.home
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kr.ksw.mybudget.data.repository.spending.SpendingRepository
 import kr.ksw.mybudget.domain.mapper.toItem
 import kr.ksw.mybudget.domain.model.SpendingItem
@@ -9,14 +11,14 @@ import javax.inject.Inject
 class GetPreviousMonthSpendingUseCaseImpl @Inject constructor(
     private val spendingRepository: SpendingRepository
 ): GetPreviousMonthSpendingUseCase {
-    override suspend fun invoke(): Result<List<SpendingItem>> = runCatching {
+    override suspend fun invoke(): Flow<List<SpendingItem>> {
         val now = LocalDate.now().plusMonths(-1L)
         val from = now.withDayOfMonth(1)
         val to = now.withDayOfMonth(now.lengthOfMonth())
-        spendingRepository.getSpendingEntitiesBetween(
-            from, to
-        ).map {
-            it.toItem()
+        return spendingRepository.getSpendingEntitiesBetween(from, to).map { list ->
+            list.map {
+                it.toItem()
+            }
         }
     }
 }

--- a/app/src/main/java/kr/ksw/mybudget/presentation/core/common/ViewModelScope.kt
+++ b/app/src/main/java/kr/ksw/mybudget/presentation/core/common/ViewModelScope.kt
@@ -1,0 +1,11 @@
+package kr.ksw.mybudget.presentation.core.common
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+fun ViewModel.viewModelLauncher(block: suspend () -> Unit) {
+    viewModelScope.launch {
+        block()
+    }
+}


### PR DESCRIPTION
## 추가사항
- CardEntity, CardDao 추가
- CardRepository 추가 및 DI 적용
- CardDaoTest 추가

## 리팩토링
- `SpendingDao`에서 `getSpendingEntitiesBetweenFlow`를 삭제
- `SpendingDao`의 `getSpendingEntitiesBetween`의 반환 타입을 Flow로 변경