### PR TITLE
[#14] 카드별 소비내역 출력

### DIFF
--- a/app/src/androidTest/java/kr/ksw/mybudget/data/local/SpendingDaoTest.kt
+++ b/app/src/androidTest/java/kr/ksw/mybudget/data/local/SpendingDaoTest.kt
@@ -183,4 +183,23 @@ class SpendingDaoTest {
         assert(result.isNotEmpty())
         assert(result.size == 1)
     }
+
+    @Test
+    fun `getSpendingEntitiesByCardNum is empty`() = runTest {
+        spendingList.forEach { spending ->
+            dao.upsertSpendingEntity(spending)
+        }
+        val result = dao.getSpendingEntitiesByCardNum("").first()
+        assert(result.isEmpty())
+    }
+
+    @Test
+    fun `getSpendingEntitiesByCardNum is not empty`() = runTest {
+        spendingList.forEach { spending ->
+            dao.upsertSpendingEntity(spending)
+        }
+        val result = dao.getSpendingEntitiesByCardNum("4885111266651115").first()
+        assert(result.isNotEmpty())
+        assert(result.size == 3)
+    }
 }

--- a/app/src/androidTest/java/kr/ksw/mybudget/data/local/mock/SpendingMock.kt
+++ b/app/src/androidTest/java/kr/ksw/mybudget/data/local/mock/SpendingMock.kt
@@ -14,14 +14,16 @@ val spendingList = listOf(
         date = LocalDate.now(),
         majorCategory = MAJOR_CATEGORY_FOOD,
         subCategory = 12,
-        price = 6_000
+        price = 6_000,
+        cardNum = "4885111266651115"
     ),
     SpendingEntity(
         title = "할리스",
         date = LocalDate.now(),
         majorCategory = MAJOR_CATEGORY_FOOD,
         subCategory = 12,
-        price = 5_000
+        price = 5_000,
+        cardNum = "4885111266651115"
     ),
     SpendingEntity(
         title = "영화",
@@ -35,7 +37,8 @@ val spendingList = listOf(
         date = LocalDate.now(),
         majorCategory = MAJOR_CATEGORY_LIFE_STYLE,
         subCategory = 31,
-        price = 100_000
+        price = 100_000,
+        cardNum = "4885111266651115"
     ),
     SpendingEntity(
         title = "통신비",

--- a/app/src/main/java/kr/ksw/mybudget/data/local/dao/SpendingDao.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/local/dao/SpendingDao.kt
@@ -34,4 +34,9 @@ interface SpendingDao {
         from: LocalDate,
         to: LocalDate
     ): Flow<List<SpendingEntity>>
+
+    @Query("SELECT * FROM spending_table WHERE cardNum = :cardNum")
+    fun getSpendingEntitiesByCardNum(
+        cardNum: String
+    ): Flow<List<SpendingEntity>>
 }

--- a/app/src/main/java/kr/ksw/mybudget/data/repository/spending/SpendingRepository.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/repository/spending/SpendingRepository.kt
@@ -16,6 +16,10 @@ interface SpendingRepository {
         to: LocalDate
     ): Flow<List<SpendingEntity>>
 
+    fun getSpendingEntitiesByCardNum(
+        cardNum: String
+    ): Flow<List<SpendingEntity>>
+
     suspend fun getSpendingEntitiesByMajorCategory(
         majorCategory: Int
     ): List<SpendingEntity>

--- a/app/src/main/java/kr/ksw/mybudget/data/repository/spending/SpendingRepositoryImpl.kt
+++ b/app/src/main/java/kr/ksw/mybudget/data/repository/spending/SpendingRepositoryImpl.kt
@@ -38,9 +38,24 @@ class SpendingRepositoryImpl @Inject constructor(
     }.catch { emit(emptyList()) }
         .flowOn(Dispatchers.IO)
 
+    override fun getSpendingEntitiesByCardNum(
+        cardNum: String
+    ): Flow<List<SpendingEntity>> = entitiesToFlow(
+        entities = spendingDao.getSpendingEntitiesByCardNum(cardNum)
+    )
+
     override suspend fun getSpendingEntitiesByMajorCategory(majorCategory: Int): List<SpendingEntity>
         = spendingDao.getSpendingEntitiesByMajorCategory(majorCategory = majorCategory)
 
     override suspend fun getSpendingEntitiesBySubCategory(subCategory: Int): List<SpendingEntity>
         = spendingDao.getSpendingEntitiesBySubCategory(subCategory = subCategory)
+
+    private fun <T> entitiesToFlow(
+        entities: Flow<List<T>>
+    ): Flow<List<T>> = flow {
+        entities.collect {
+            emit(it)
+        }
+    }.catch { emit(emptyList()) }
+        .flowOn(Dispatchers.IO)
 }

--- a/app/src/main/java/kr/ksw/mybudget/domain/di/SpendingModule.kt
+++ b/app/src/main/java/kr/ksw/mybudget/domain/di/SpendingModule.kt
@@ -6,6 +6,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.components.ActivityRetainedComponent
 import kr.ksw.mybudget.domain.usecase.add.spending.AddSpendingUseCase
 import kr.ksw.mybudget.domain.usecase.add.spending.AddSpendingUseCaseImpl
+import kr.ksw.mybudget.domain.usecase.card.GetSpendingListByCardNumUseCase
+import kr.ksw.mybudget.domain.usecase.card.GetSpendingListByCardNumUseCaseImpl
 import kr.ksw.mybudget.domain.usecase.home.GetMonthlySpendingUseCase
 import kr.ksw.mybudget.domain.usecase.home.GetMonthlySpendingUseCaseImpl
 import kr.ksw.mybudget.domain.usecase.home.GetPreviousMonthSpendingUseCase
@@ -28,4 +30,9 @@ abstract class SpendingModule {
     abstract fun bindGetPreviousMonthSpendingUSeCase(
         getPreviousMonthSpendingUseCase: GetPreviousMonthSpendingUseCaseImpl
     ): GetPreviousMonthSpendingUseCase
+
+    @Binds
+    abstract fun bindGetSpendingListByCardNumUseCase(
+        getSpendingListByCardNumUseCase: GetSpendingListByCardNumUseCaseImpl
+    ): GetSpendingListByCardNumUseCase
 }

--- a/app/src/main/java/kr/ksw/mybudget/domain/usecase/card/GetSpendingListByCardNumUseCase.kt
+++ b/app/src/main/java/kr/ksw/mybudget/domain/usecase/card/GetSpendingListByCardNumUseCase.kt
@@ -1,0 +1,8 @@
+package kr.ksw.mybudget.domain.usecase.card
+
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.mybudget.domain.model.spending.SpendingItem
+
+interface GetSpendingListByCardNumUseCase {
+    operator fun invoke(cardNum: String): Flow<List<SpendingItem>>
+}

--- a/app/src/main/java/kr/ksw/mybudget/domain/usecase/card/GetSpendingListByCardNumUseCaseImpl.kt
+++ b/app/src/main/java/kr/ksw/mybudget/domain/usecase/card/GetSpendingListByCardNumUseCaseImpl.kt
@@ -1,0 +1,19 @@
+package kr.ksw.mybudget.domain.usecase.card
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kr.ksw.mybudget.data.repository.spending.SpendingRepository
+import kr.ksw.mybudget.domain.mapper.toItem
+import kr.ksw.mybudget.domain.model.spending.SpendingItem
+import javax.inject.Inject
+
+class GetSpendingListByCardNumUseCaseImpl @Inject constructor(
+    private val spendingRepository: SpendingRepository
+): GetSpendingListByCardNumUseCase {
+    override fun invoke(cardNum: String): Flow<List<SpendingItem>> =
+        spendingRepository.getSpendingEntitiesByCardNum(cardNum).map { list ->
+            list.map {
+                it.toItem()
+            }
+        }
+}

--- a/app/src/main/java/kr/ksw/mybudget/presentation/add/spending/viewmodel/AddSpendingViewModel.kt
+++ b/app/src/main/java/kr/ksw/mybudget/presentation/add/spending/viewmodel/AddSpendingViewModel.kt
@@ -53,7 +53,15 @@ class AddSpendingViewModel @Inject constructor(
                     ))
                 } else {
                     viewModelScope.launch {
-                        addSpendingUseCase(state.value.item)
+                        if(state.value.cardList.isNotEmpty() &&
+                            spendingItem.cardNum == null) {
+                            val newItem = spendingItem.copy(
+                                cardNum = state.value.cardList[state.value.selectedCardIndex].cardNumber
+                            )
+                            addSpendingUseCase(newItem)
+                        } else {
+                            addSpendingUseCase(spendingItem)
+                        }
                     }
                     postUIEffect(AddSpendingUIEffect.FinishAddScreen)
                 }
@@ -79,7 +87,7 @@ class AddSpendingViewModel @Inject constructor(
                             } else {
                                 index
                             }
-                        } ?: 0
+                        } ?: 0,
                     )
                 }
             }

--- a/app/src/main/java/kr/ksw/mybudget/presentation/card/list/screen/CardListScreen.kt
+++ b/app/src/main/java/kr/ksw/mybudget/presentation/card/list/screen/CardListScreen.kt
@@ -85,6 +85,15 @@ fun CardListScreen(
     state: CardListState,
     onAction: (CardListActions) -> Unit
 ) {
+    val spendingList = state.spendingList.filter {
+        val cardNum = if(state.cardList.isEmpty()) {
+            ""
+        } else {
+            state.cardList[state.selectedCardIndex].cardNumber
+        }
+        it.cardNum == cardNum
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -129,7 +138,6 @@ fun CardListScreen(
                     )
                 }
             } else {
-                val spendingList = state.spendingList
                 LazyColumn(
                     modifier = Modifier
                         .padding(horizontal = Paddings.ScaffoldHorizontalPadding),

--- a/app/src/main/java/kr/ksw/mybudget/presentation/card/list/screen/CardListScreen.kt
+++ b/app/src/main/java/kr/ksw/mybudget/presentation/card/list/screen/CardListScreen.kt
@@ -1,6 +1,5 @@
 package kr.ksw.mybudget.presentation.card.list.screen
 
-import android.content.Context
 import android.content.Intent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -49,8 +48,8 @@ import kr.ksw.mybudget.presentation.card.list.viewmodel.CardListUIEffect
 import kr.ksw.mybudget.presentation.card.list.viewmodel.CardListViewModel
 import kr.ksw.mybudget.presentation.components.CardUi
 import kr.ksw.mybudget.presentation.components.SpendingCard
-import kr.ksw.mybudget.ui.Paddings
 import kr.ksw.mybudget.presentation.core.keys.CARD_ITEM_KEY
+import kr.ksw.mybudget.ui.Paddings
 import kr.ksw.mybudget.ui.theme.MyBudgetTheme
 import kotlin.math.absoluteValue
 
@@ -86,18 +85,12 @@ fun CardListScreen(
     state: CardListState,
     onAction: (CardListActions) -> Unit
 ) {
-    val context = LocalContext.current
-    val spendingItems = state.spendingList.filter {
-        it.cardNum == state.cardList[state.selectedCardIndex].cardNumber
-    }
-
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(top = Paddings.ScaffoldTopPadding)
     ) {
         CardListHeader(
-            context = context,
             onAction = onAction
         )
         Spacer(modifier = Modifier.height(20.dp))
@@ -126,7 +119,7 @@ fun CardListScreen(
                 fontSize = 18.sp
             )
             Spacer(modifier = Modifier.height(6.dp))
-            if(spendingItems.isEmpty()) {
+            if(state.spendingList.isEmpty()) {
                 Box(
                     modifier = Modifier.fillMaxSize()
                 ) {
@@ -136,6 +129,7 @@ fun CardListScreen(
                     )
                 }
             } else {
+                val spendingList = state.spendingList
                 LazyColumn(
                     modifier = Modifier
                         .padding(horizontal = Paddings.ScaffoldHorizontalPadding),
@@ -143,13 +137,13 @@ fun CardListScreen(
                     verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
                     items(
-                        count = spendingItems.size,
+                        count = spendingList.size,
                         key = {
                             it
                         }
                     ) { index ->
                         SpendingCard(
-                            item = spendingItems[index]
+                            item = spendingList[index]
                         ) {
 
                         }
@@ -162,7 +156,6 @@ fun CardListScreen(
 
 @Composable
 private fun CardListHeader(
-    context: Context,
     onAction: (CardListActions) -> Unit
 ) {
     Row(

--- a/app/src/main/java/kr/ksw/mybudget/presentation/card/list/viewmodel/CardListViewModel.kt
+++ b/app/src/main/java/kr/ksw/mybudget/presentation/card/list/viewmodel/CardListViewModel.kt
@@ -1,10 +1,7 @@
 package kr.ksw.mybudget.presentation.card.list.viewmodel
 
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.update
 import kr.ksw.mybudget.domain.model.card.CardItem
 import kr.ksw.mybudget.domain.usecase.add.card.GetAllCardUseCase
 import kr.ksw.mybudget.presentation.core.common.BaseViewModel

--- a/app/src/main/java/kr/ksw/mybudget/presentation/card/list/viewmodel/CardListViewModel.kt
+++ b/app/src/main/java/kr/ksw/mybudget/presentation/card/list/viewmodel/CardListViewModel.kt
@@ -3,20 +3,28 @@ package kr.ksw.mybudget.presentation.card.list.viewmodel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kr.ksw.mybudget.domain.model.card.CardItem
+import kr.ksw.mybudget.domain.model.spending.SpendingItem
 import kr.ksw.mybudget.domain.usecase.add.card.GetAllCardUseCase
+import kr.ksw.mybudget.domain.usecase.home.GetMonthlySpendingUseCase
 import kr.ksw.mybudget.presentation.core.common.BaseViewModel
 import kr.ksw.mybudget.presentation.core.common.viewModelLauncher
 import javax.inject.Inject
 
 @HiltViewModel
 class CardListViewModel @Inject constructor(
-    private val getAllCardUseCase: GetAllCardUseCase
+    private val getAllCardUseCase: GetAllCardUseCase,
+    private val getMonthlySpendingUseCase: GetMonthlySpendingUseCase
 ): BaseViewModel<CardListState, CardListUIEffect>(CardListState()) {
 
     init {
         viewModelLauncher {
             getAllCardUseCase().collectLatest {
                 updateCardList(it)
+            }
+        }
+        viewModelLauncher {
+            getMonthlySpendingUseCase().collectLatest {
+                updateSpendingList(it)
             }
         }
     }
@@ -51,6 +59,16 @@ class CardListViewModel @Inject constructor(
         updateState {
             it.copy(
                 cardList = cardList
+            )
+        }
+    }
+
+    private fun updateSpendingList(
+        spendingList: List<SpendingItem>
+    ) {
+        updateState {
+            it.copy(
+                spendingList = spendingList
             )
         }
     }

--- a/app/src/main/java/kr/ksw/mybudget/presentation/home/screen/HomeScreen.kt
+++ b/app/src/main/java/kr/ksw/mybudget/presentation/home/screen/HomeScreen.kt
@@ -66,7 +66,8 @@ fun HomeScreen(
     state: HomeState
 ) {
     val now = LocalDate.now().toDisplayString(DATE_FORMAT_YMD)
-    val name = "김석우"
+    // No User Data
+    val name = stringResource(R.string.main_home_user_name_default)
 
     val context = LocalContext.current
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="display_currency_won">%s원</string>
 
     <string name="main_home_header_name_title">%s님 안녕하세요!</string>
+    <string name="main_home_user_name_default">처음 사용자</string>
 
     <string name="main_home_spending_card_title">이번 달 지출</string>
     <string name="main_home_spending_card_compare_title">전월대비</string>


### PR DESCRIPTION
### 변경사항
- 카드 번호로 CardEntitiy 조회하는 `getSpendingEntitiesByCardNum` 함수 `SpendingDao`에 추가
- `GetSpendingListByCardNumUseCase` 추가
- 월별 소비내역에서 카드번호로 Filter하는 기능 추가 -> `CardListScreen`

### 유의사항
- 카드 번호로 소비내역 조회 기능을 추가했으나, Compose와 ViewModel에서 쓰기 어려워 사용하지 않고있음.